### PR TITLE
Generate/embedding

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -6,3 +6,7 @@ load_dotenv()
 NCBI_EMAIL = os.getenv("NCBI_EMAIL")
 NCBI_API_KEY = os.getenv("NCBI_API_KEY")
 
+PROCESSED_DATA_PATH = "./data/processed"
+FAISS_INDEX_PATH = "./faiss_index.bin"
+ES_INDEX_NAME = "medical_documents"
+MODEL_NAME = "bert-base-multilingual-cased"

--- a/scripts/preprocessing/embedding.py
+++ b/scripts/preprocessing/embedding.py
@@ -31,3 +31,11 @@ def load_data(directory):
                 else:
                     documents.append(data)
     return documents
+
+
+def create_and_save_faiss_index(embeddings, documents):
+    dimension = embeddings.shape[1]
+    index = faiss.IndexFlatL2(dimension)  # L2 distance for similarity search
+    index.add(embeddings)
+    faiss.write_index(index, FAISS_INDEX_PATH)
+    print(f"FAISS index created and saved to {FAISS_INDEX_PATH}")

--- a/scripts/preprocessing/embedding.py
+++ b/scripts/preprocessing/embedding.py
@@ -1,0 +1,18 @@
+import json
+import os
+from transformers import AutoTokenizer, AutoModel
+import torch
+from config.settings import MODEL_NAME, PROCESSED_DATA_PATH
+
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+model = AutoModel.from_pretrained(MODEL_NAME)
+
+
+def get_document_embeddings(texts):
+    inputs = tokenizer(
+        texts, padding=True, truncation=True, return_tensors="pt", max_length=512
+    )
+    with torch.no_grad():
+        model_output = model(**inputs)
+    embeddings = model_output.last_hidden_state[:, 0, :].numpy()
+    return embeddings

--- a/scripts/preprocessing/embedding.py
+++ b/scripts/preprocessing/embedding.py
@@ -1,8 +1,9 @@
 import json
 import os
+import faiss
 from transformers import AutoTokenizer, AutoModel
 import torch
-from config.settings import MODEL_NAME, PROCESSED_DATA_PATH
+from config.settings import MODEL_NAME, PROCESSED_DATA_PATH, FAISS_INDEX_PATH
 
 tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
 model = AutoModel.from_pretrained(MODEL_NAME)
@@ -16,3 +17,17 @@ def get_document_embeddings(texts):
         model_output = model(**inputs)
     embeddings = model_output.last_hidden_state[:, 0, :].numpy()
     return embeddings
+
+
+def load_data(directory):
+    documents = []
+    for filename in os.listdir(directory):
+        if filename.endswith(".json"):
+            filepath = os.path.join(directory, filename)
+            with open(filepath, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, list):
+                    documents.extend(data)
+                else:
+                    documents.append(data)
+    return documents


### PR DESCRIPTION
This pull request introduces new functionality for processing and embedding medical documents, including the creation of a FAISS index for similarity search. The changes involve adding new configuration settings, implementing document embedding logic, and enabling FAISS index creation.

### Configuration Updates:
* Added new settings in `config/settings.py` for specifying paths and model details: `PROCESSED_DATA_PATH`, `FAISS_INDEX_PATH`, `ES_INDEX_NAME`, and `MODEL_NAME`. These settings provide configurable paths and model information for document processing and embedding tasks.

### Embedding and Indexing Functionality:
* Introduced a new script `scripts/preprocessing/embedding.py` to handle document embedding and FAISS index creation. Key additions include:
  - Loading a pre-trained BERT model (`bert-base-multilingual-cased`) and tokenizer for generating embeddings.
  - Functions for processing document data (`load_data`), computing embeddings (`get_document_embeddings`), and creating/saving a FAISS index (`create_and_save_faiss_index`). These functions enable efficient similarity search capabilities.